### PR TITLE
Python3 docker container

### DIFF
--- a/base-minimal.Dockerfile
+++ b/base-minimal.Dockerfile
@@ -4,7 +4,7 @@
 #   - Unsafe (root) user is used only when USERNAME is overridden with 'root'
 
 # Base image must be 18.04. Some packages we want do not exist in 20.04.
-FROM ubuntu:18.04
+FROM ubuntu:20.04
 
 LABEL Maintainer="Rod Glover <rglover@uvic.ca>"
 
@@ -14,9 +14,9 @@ RUN apt-get update
 
 # Install Ubuntu packages
 RUN apt-get install -yq \
-        python2.7 \
-        python2.7-dev \
-        python-pip \
+        python3.8 \
+        python3.8-dev \
+        python3-pip \
         build-essential \
         libhdf5-dev \
         libgdal-dev \
@@ -57,7 +57,8 @@ WORKDIR ${USER_DIR}
 USER ${USERNAME}
 
 # Install Python build packages
-RUN pip install --upgrade pip setuptools wheel
+RUN pip install --upgrade pip wheel
+RUN pip install setuptools==57.5.0
 
 # Set up environment variables for Python installs and builds
 ENV CPLUS_INCLUDE_PATH /usr/include/gdal
@@ -66,7 +67,8 @@ ENV PIP_INDEX_URL https://pypi.pacificclimate.org/simple
 
 # Install primary dependencies (separate RUN statement for GDAL is required).
 # Other project dependencies will be installed by images derived from this one.
-RUN pip install --no-binary :all: numpy==1.16.6 Cython==0.22 gdal==2.2
-RUN pip install --no-binary :all: h5py==2.7.1
+RUN pip install --no-binary :all: numpy==1.16.6
+# Cython==0.27
+RUN pip install --no-binary :all: h5py==2.7.1 gdal==3.0.4
 
 ENV PATH=${USER_DIR}/.local/bin:${PATH}


### PR DESCRIPTION
I attempted to make a python 3 docker container to develop the PDP on my workstation with by modifying the base pdp (python2) dockerfile. 

This PR is just to compare the two files; we don't want to merge and overwrite the python2 dockerfile with a python3 dockerfile. Once we have a python3 dockerfile we like, we'll add it as a new file to this repo.